### PR TITLE
feat: adicionar validação manual e logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Aplicativo desktop em Python/PySide6 para enviar formulários e validar assinatu
 - Controle de status de assinatura (pendente ou assinado).
 - Sincronização com WhatsApp via QR Code.
 - Comandos no chat como `/assinar` e `/status` para automatizar o fluxo.
+- Validação manual com indicador de revisão e registro de histórico.
 
 ## Estrutura
 
@@ -61,6 +62,12 @@ assinar-desktop/
 # Gerar executável
 ./make.ps1 build
 ```
+
+## Validação manual e histórico
+
+- O dashboard possui um campo indicando se o documento foi revisado e confirmado.
+- Ao receber o formulário assinado, anexe-o ao cadastro e marque o status como "assinado" ou "validado".
+- Todas as ações são registradas para facilitar auditorias futuras.
 
 ## Autor
 

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import (
     mapped_column,
     relationship,
 )
-from sqlalchemy import Integer, String, Text, ForeignKey
+from sqlalchemy import Integer, String, Text, ForeignKey, Boolean
 
 Base = declarative_base()
 
@@ -41,6 +41,7 @@ class Document(Base):
     customer_id: Mapped[int] = mapped_column(ForeignKey("customers.id"), nullable=False)
     file_path: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, default="pendente", nullable=False)
+    reviewed: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     customer: Mapped["Customer"] = relationship("Customer", back_populates="documents")
 
 

--- a/app/ui/card.py
+++ b/app/ui/card.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
     QFileDialog,
 )
 
-from app.core.models import Customer, Document
+from app.core.models import Customer, Document, AuditLog
 from app.flows.send_form import send_form_pdf
 
 
@@ -29,16 +29,23 @@ class CustomerCard(QFrame):
         )
         self.lbl_status = QLabel(f"Status: {status}")
         layout.addWidget(self.lbl_status)
+        revisado = (
+            "Sim" if cliente.documents and cliente.documents[0].reviewed else "Não"
+        )
+        self.lbl_reviewed = QLabel(f"Revisado: {revisado}")
+        layout.addWidget(self.lbl_reviewed)
 
         actions = QHBoxLayout()
         self.btn_first_contact = QPushButton("1º contato")
         self.btn_send_form = QPushButton("Enviar PDF")
         self.btn_validate = QPushButton("Marcar assinado")
+        self.btn_review = QPushButton("Marcar validado")
         self.btn_resend = QPushButton("Reenviar")
         for btn in (
             self.btn_first_contact,
             self.btn_send_form,
             self.btn_validate,
+            self.btn_review,
             self.btn_resend,
         ):
             actions.addWidget(btn)
@@ -46,6 +53,7 @@ class CustomerCard(QFrame):
 
         self.btn_send_form.clicked.connect(self.enviar_formulario)
         self.btn_validate.clicked.connect(self.marcar_assinado)
+        self.btn_review.clicked.connect(self.marcar_validado)
 
     def enviar_formulario(self) -> None:
         """Seleciona um PDF e envia ao cliente."""
@@ -58,13 +66,43 @@ class CustomerCard(QFrame):
                 customer=self.cliente, file_path=file_path, status="pendente"
             )
             self.session.add(documento)
+            self.session.add(
+                AuditLog(
+                    actor="dashboard",
+                    action="enviar_pdf",
+                    payload=str(self.cliente.id),
+                )
+            )
             self.session.commit()
             self.lbl_status.setText("Status: pendente")
+            self.lbl_reviewed.setText("Revisado: Não")
 
     def marcar_assinado(self) -> None:
         """Atualiza o status do documento para assinado."""
         if self.cliente.documents:
             doc = self.cliente.documents[0]
             doc.status = "assinado"
+            doc.reviewed = False
+            self.session.add(
+                AuditLog(
+                    actor="dashboard", action="marcar_assinado", payload=str(doc.id)
+                )
+            )
             self.session.commit()
             self.lbl_status.setText("Status: assinado")
+            self.lbl_reviewed.setText("Revisado: Não")
+
+    def marcar_validado(self) -> None:
+        """Atualiza o status do documento para validado."""
+        if self.cliente.documents:
+            doc = self.cliente.documents[0]
+            doc.status = "validado"
+            doc.reviewed = True
+            self.session.add(
+                AuditLog(
+                    actor="dashboard", action="marcar_validado", payload=str(doc.id)
+                )
+            )
+            self.session.commit()
+            self.lbl_status.setText("Status: validado")
+            self.lbl_reviewed.setText("Revisado: Sim")

--- a/app/ui/dashboard.py
+++ b/app/ui/dashboard.py
@@ -27,7 +27,7 @@ class Dashboard(QWidget):
         layout.addWidget(self.filtro_empresa)
 
         self.filtro_status = QComboBox()
-        self.filtro_status.addItems(["Todos", "Pendente", "Assinado"])
+        self.filtro_status.addItems(["Todos", "Pendente", "Assinado", "Validado"])
         layout.addWidget(self.filtro_status)
 
         self.lista = QListWidget()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,5 +23,6 @@ def test_relationships_and_defaults():
     assert cliente.company.name == "MRV"
     assert cliente.documents[0].status == "pendente"
     assert cliente.documents[0].file_path == "contrato.pdf"
+    assert cliente.documents[0].reviewed is False
 
     session.close()


### PR DESCRIPTION
## Resumo
- adicionar flag de revisão e status **validado** para documentos
- registrar logs ao enviar, assinar e validar arquivos
- exibir filtro e indicadores de revisão no dashboard
- documentar processo de validação manual
