### PR TITLE
feat: ícone de bandeja e notificações

### DIFF
--- a/app/flows/send_form.py
+++ b/app/flows/send_form.py
@@ -1,6 +1,7 @@
 """Envio de link e tutorial para o cliente."""
 
 from app.services import whatsapp
+from app.ui.tray import TrayIcon
 
 
 def send_form_link(phone: str, url: str) -> None:
@@ -13,3 +14,5 @@ def send_form_pdf(phone: str, file_path: str, caption: str = "") -> None:
     media_id = whatsapp.upload_media(file_path)
     if media_id:
         whatsapp.send_document(phone, media_id, caption)
+        destinatario = caption or phone
+        TrayIcon.notify_global(f"PDF enviado para {destinatario}")

--- a/app/flows/validate_and_notify.py
+++ b/app/flows/validate_and_notify.py
@@ -1,11 +1,15 @@
 """Valida a assinatura e notifica o cliente."""
 
 from app.services import validator, whatsapp
+from app.ui.tray import TrayIcon
 
 
 def validate_and_notify(phone: str, p7s: bytes) -> None:
     """Valida o arquivo assinado e avisa o cliente."""
     if validator.validate_signature(p7s):
         whatsapp.send_message(phone, "Assinatura validada com sucesso!")
+        TrayIcon.notify_global(
+            f"Assinatura de {phone} validada com sucesso!"
+        )
     else:
         whatsapp.send_message(phone, "Falha na validação da assinatura.")

--- a/app/ui/tray.py
+++ b/app/ui/tray.py
@@ -1,19 +1,31 @@
 """Ícone de bandeja com ações rápidas e status do túnel."""
 
-from PySide6.QtGui import QIcon
+# Autor: Pexe – Instagram: @David.devloli
+
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QIcon, QPixmap, QPainter, QColor
 from PySide6.QtWidgets import QSystemTrayIcon, QMenu, QApplication
 
 
 class TrayIcon(QSystemTrayIcon):
     """Gerencia o ícone de bandeja da aplicação."""
 
+    instance: "TrayIcon | None" = None
+
     def __init__(self, url: str | None = None, parent=None) -> None:
-        super().__init__(QIcon(), parent)
+        icon_path = Path(__file__).resolve().parents[2] / "assets" / "tray_icon.png"
+        super().__init__(QIcon(str(icon_path)), parent)
+        TrayIcon.instance = self
+
         self.url: str | None = url
         menu = QMenu()
         self.action_copy = menu.addAction("Copiar URL")
         self.action_copy.triggered.connect(self.copy_url)
         menu.addSeparator()
+        self.icon_ok = self._status_icon("#28a745")
+        self.icon_error = self._status_icon("#dc3545")
         self.webhook_status = menu.addAction("Webhooks: desconhecido")
         self.setContextMenu(menu)
         self.update_url(url)
@@ -34,4 +46,28 @@ class TrayIcon(QSystemTrayIcon):
     def update_webhooks_status(self, ok: bool) -> None:
         """Exibe no menu o status dos webhooks."""
         texto = "Webhooks OK" if ok else "Webhooks com erro"
+        icon = self.icon_ok if ok else self.icon_error
+        self.webhook_status.setIcon(icon)
         self.webhook_status.setText(texto)
+
+    def notify(self, message: str, title: str = "Assinador") -> None:
+        """Exibe uma notificação nativa do sistema."""
+        self.showMessage(title, message, self.icon())
+
+    @classmethod
+    def notify_global(cls, message: str, title: str = "Assinador") -> None:
+        """Atalho para exibir notificação usando a instância ativa."""
+        if cls.instance is not None:
+            cls.instance.notify(message, title)
+
+    @staticmethod
+    def _status_icon(color: str) -> QIcon:
+        pixmap = QPixmap(16, 16)
+        pixmap.fill(Qt.transparent)
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.Antialiasing)
+        painter.setBrush(QColor(color))
+        painter.setPen(Qt.NoPen)
+        painter.drawEllipse(0, 0, 16, 16)
+        painter.end()
+        return QIcon(pixmap)


### PR DESCRIPTION
## Resumo
- adiciona ícone próprio para o aplicativo e status coloridos dos webhooks
- implementa toasts nativos para envio de PDFs e validações de assinatura
- remove arquivo de ícone da bandeja do versionamento

## Testes
- `pytest`

Autor: Pexe (instagram: David.devloli)

------
https://chatgpt.com/codex/tasks/task_b_68ba500ed4fc832291c661c1c0b6ec52