### PR TITLE
Habilita debug no DevTools para facilitar diagnóstico

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -14,5 +14,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   addClient: (company, data) => ipcRenderer.invoke('add-client', company, data),
   updateClient: (company, id, data) => ipcRenderer.invoke('update-client', company, id, data),
   deleteClient: (company, id) => ipcRenderer.invoke('delete-client', company, id),
-  removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel)
+  removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel),
+  onDebugLog: (callback) => ipcRenderer.on('debug-log', (_e, data) => callback(data))
 });

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -5,6 +5,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const btnAddWhatsAppAccount = document.getElementById('btn-add-whatsapp-account');
     const modalOverlay = document.getElementById('custom-modal-overlay');
 
+    // Recebe logs do processo principal e exibe no console do DevTools
+    window.electronAPI.onDebugLog(({ level, message }) => {
+        const log = console[level] || console.log;
+        log(`[MAIN] ${message}`);
+    });
+
     /* Navegação principal */
     const navLinks = document.querySelectorAll('.navigation a');
     const viewsMap = {


### PR DESCRIPTION
## Resumo
- Abre DevTools automaticamente e redireciona logs do processo principal
- Expõe evento de debug no preload e mostra logs na interface renderer
